### PR TITLE
Wallet sdk test exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -499,6 +499,26 @@ export declare class Peer {
    */
   simulatorNewCoin(puzzleHash: Buffer, amount: bigint): Promise<Coin>
   /**
+   * Gets the current height of the simulator.
+   *
+   * @returns {Promise<u32>} The current height.
+   */
+  simulatorHeight(): Promise<number>
+  /**
+   * Gets the coin state for a given coin ID.
+   *
+   * @param {Buffer} coinId - The coin ID to look up.
+   * @returns {Promise<CoinState | null>} The coin state if found.
+   */
+  simulatorCoinState(coinId: Buffer): Promise<CoinState | null>
+  /**
+   * Gets the header hash at the specified height.
+   *
+   * @param {u32} height - The height to get the header hash for.
+   * @returns {Promise<Buffer>} The header hash.
+   */
+  headerHash(height: number): Promise<Buffer>
+  /**
    * Retrieves all hinted coin states that are unspent on the chain. Note that coins part of spend bundles that are pending in the mempool will also be included.
    *
    * @param {Buffer} puzzleHash - Puzzle hash to lookup hinted coins for.

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,11 @@ export interface SimulatorPuzzle {
   puzzleHash: Buffer
   puzzleReveal: Buffer
 }
+export interface BlsPair {
+  sk: Buffer
+  pk: Buffer
+  puzzleHash: Buffer
+}
 /**
  * Creates a new lineage proof.
  *
@@ -480,6 +485,13 @@ export declare class Peer {
    * @returns {Promise<js::SimulatorPuzzle>} The puzzle hash and reveal.
    */
   simulatorNewPuzzle(value: bigint): Promise<SimulatorPuzzle>
+  /**
+   * Creates a new BlsPair.
+   *
+   * @param {BigInt} value - The value to use to initialize the pair.
+   * @returns {Promise<js::BlsPair>} The BlsPair.
+   */
+  simulatorNewBlspair(value: bigint): Promise<BlsPair>
   /**
    * Retrieves all hinted coin states that are unspent on the chain. Note that coins part of spend bundles that are pending in the mempool will also be included.
    *

--- a/index.d.ts
+++ b/index.d.ts
@@ -442,6 +442,26 @@ export declare function getMainnetGenesisChallenge(): Buffer
  * @returns {Buffer} The testnet11 genesis challenge.
  */
 export declare function getTestnet11GenesisChallenge(): Buffer
+/**
+ * Creates a new puzzle and its hash using the simulator.
+ *
+ * @param {BigInt} value - The value to use for the puzzle.
+ * @returns {Promise<js::SimulatorPuzzle>} The puzzle hash and reveal.
+ */
+export declare function simulatorNewPuzzle(value: bigint): Promise<SimulatorPuzzle>
+/**
+ * Creates a new BlsPair.
+ *
+ * @param {BigInt} value - The value to use to initialize the pair.
+ * @returns {Promise<js::BlsPair>} The BlsPair.
+ */
+export declare function simulatorNewBlspair(value: bigint): BlsPair
+/**
+ * Creates a new simulator program.
+ *
+ * @returns {Promise<Buffer>} The program.
+ */
+export declare function simulatorNewProgram(pk: Buffer): Buffer
 export declare class Tls {
   /**
    * Creates a new TLS connector.
@@ -478,26 +498,6 @@ export declare class Peer {
    * @returns {Promise<Coin>} The newly created coin.
    */
   simulatorNewCoin(puzzleHash: Buffer, amount: bigint): Promise<Coin>
-  /**
-   * Creates a new puzzle and its hash using the simulator.
-   *
-   * @param {BigInt} value - The value to use for the puzzle.
-   * @returns {Promise<js::SimulatorPuzzle>} The puzzle hash and reveal.
-   */
-  simulatorNewPuzzle(value: bigint): Promise<SimulatorPuzzle>
-  /**
-   * Creates a new BlsPair.
-   *
-   * @param {BigInt} value - The value to use to initialize the pair.
-   * @returns {Promise<js::BlsPair>} The BlsPair.
-   */
-  simulatorNewBlspair(value: bigint): BlsPair
-  /**
-   * Creates a new simulator program.
-   *
-   * @returns {Promise<Buffer>} The program.
-   */
-  simulatorNewProgram(pk: Buffer): Buffer
   /**
    * Retrieves all hinted coin states that are unspent on the chain. Note that coins part of spend bundles that are pending in the mempool will also be included.
    *

--- a/index.d.ts
+++ b/index.d.ts
@@ -491,7 +491,13 @@ export declare class Peer {
    * @param {BigInt} value - The value to use to initialize the pair.
    * @returns {Promise<js::BlsPair>} The BlsPair.
    */
-  simulatorNewBlspair(value: bigint): Promise<BlsPair>
+  simulatorNewBlspair(value: bigint): BlsPair
+  /**
+   * Creates a new simulator program.
+   *
+   * @returns {Promise<Buffer>} The program.
+   */
+  simulatorNewProgram(pk: Buffer): Buffer
   /**
    * Retrieves all hinted coin states that are unspent on the chain. Note that coins part of spend bundles that are pending in the mempool will also be included.
    *

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,6 +83,11 @@ export interface ServerCoin {
   p2PuzzleHash: Buffer
   memoUrls: Array<string>
 }
+/** Object returned by simulator_new_puzzle, containing both the puzzle hash and the puzzle reveal. */
+export interface SimulatorPuzzle {
+  puzzleHash: Buffer
+  puzzleReveal: Buffer
+}
 /**
  * Creates a new lineage proof.
  *
@@ -460,6 +465,21 @@ export declare class Peer {
    * @returns {Promise<UnspentCoinsResponse>} The unspent coins response.
    */
   getAllUnspentCoins(puzzleHash: Buffer, previousHeight: number | undefined | null, previousHeaderHash: Buffer): Promise<UnspentCoinsResponse>
+  /**
+   * Creates a new coin with the specified puzzle hash and amount using the simulator.
+   *
+   * @param {Buffer} puzzleHash - The puzzle hash for the new coin.
+   * @param {BigInt} amount - The amount for the new coin.
+   * @returns {Promise<Coin>} The newly created coin.
+   */
+  simulatorNewCoin(puzzleHash: Buffer, amount: bigint): Promise<Coin>
+  /**
+   * Creates a new puzzle and its hash using the simulator.
+   *
+   * @param {BigInt} value - The value to use for the puzzle.
+   * @returns {Promise<js::SimulatorPuzzle>} The puzzle hash and reveal.
+   */
+  simulatorNewPuzzle(value: bigint): Promise<SimulatorPuzzle>
   /**
    * Retrieves all hinted coin states that are unspent on the chain. Note that coins part of spend bundles that are pending in the mempool will also be included.
    *

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { newLineageProof, newEveProof, Tls, Peer, PeerType, selectCoins, sendXch, morphLauncherId, createServerCoin, mintStore, oracleSpend, addFee, masterPublicKeyToWalletSyntheticKey, masterPublicKeyToFirstPuzzleHash, masterSecretKeyToWalletSyntheticSecretKey, secretKeyToPublicKey, puzzleHashToAddress, addressToPuzzleHash, adminDelegatedPuzzleFromKey, writerDelegatedPuzzleFromKey, oracleDelegatedPuzzle, signCoinSpends, getCoinId, updateStoreMetadata, updateStoreOwnership, meltStore, signMessage, verifySignedMessage, syntheticKeyToPuzzleHash, getCost, getMainnetGenesisChallenge, getTestnet11GenesisChallenge } = nativeBinding
+const { newLineageProof, newEveProof, Tls, Peer, PeerType, selectCoins, sendXch, morphLauncherId, createServerCoin, mintStore, oracleSpend, addFee, masterPublicKeyToWalletSyntheticKey, masterPublicKeyToFirstPuzzleHash, masterSecretKeyToWalletSyntheticSecretKey, secretKeyToPublicKey, puzzleHashToAddress, addressToPuzzleHash, adminDelegatedPuzzleFromKey, writerDelegatedPuzzleFromKey, oracleDelegatedPuzzle, signCoinSpends, getCoinId, updateStoreMetadata, updateStoreOwnership, meltStore, signMessage, verifySignedMessage, syntheticKeyToPuzzleHash, getCost, getMainnetGenesisChallenge, getTestnet11GenesisChallenge, simulatorNewPuzzle, simulatorNewBlspair, simulatorNewProgram } = nativeBinding
 
 module.exports.newLineageProof = newLineageProof
 module.exports.newEveProof = newEveProof
@@ -344,3 +344,6 @@ module.exports.syntheticKeyToPuzzleHash = syntheticKeyToPuzzleHash
 module.exports.getCost = getCost
 module.exports.getMainnetGenesisChallenge = getMainnetGenesisChallenge
 module.exports.getTestnet11GenesisChallenge = getTestnet11GenesisChallenge
+module.exports.simulatorNewPuzzle = simulatorNewPuzzle
+module.exports.simulatorNewBlspair = simulatorNewBlspair
+module.exports.simulatorNewProgram = simulatorNewProgram

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-darwin-arm64",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-darwin-x64",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-linux-arm64-gnu",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-linux-x64-gnu",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-win32-x64-msvc",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "main": "index.js",
   "types": "index.d.ts",
   "repository": {

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -178,6 +178,26 @@ impl ToJs<js::SimulatorPuzzle> for rust::SimulatorPuzzle {
     }
 }
 
+impl FromJs<js::BlsPair> for rust::BlsPair {
+    fn from_js(value: js::BlsPair) -> Result<Self> {
+        Ok(Self {
+            puzzle_hash: Bytes32::from_js(value.puzzle_hash)?,
+            pk: PublicKey::from_js(value.pk)?,
+            sk: SecretKey::from_js(value.sk)?,
+        })
+    }
+}
+
+impl ToJs<js::BlsPair> for rust::BlsPair {
+    fn to_js(&self) -> Result<js::BlsPair> {
+        Ok(js::BlsPair {
+            puzzle_hash: self.puzzle_hash.to_js()?,
+            pk: self.pk.to_js()?,
+            sk: self.sk.to_js()?,
+        })
+    }
+}
+
 impl FromJs<js::CoinState> for rust::CoinState {
     fn from_js(value: js::CoinState) -> Result<Self> {
         Ok(Self {

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -159,6 +159,25 @@ impl ToJs<js::Coin> for rust::Coin {
     }
 }
 
+
+impl FromJs<js::SimulatorPuzzle> for rust::SimulatorPuzzle {
+    fn from_js(value: js::SimulatorPuzzle) -> Result<Self> {
+        Ok(Self {
+            puzzle_hash: Bytes32::from_js(value.puzzle_hash)?,
+            puzzle_reveal: Program::from_js(value.puzzle_reveal)?,
+        })
+    }
+}
+
+impl ToJs<js::SimulatorPuzzle> for rust::SimulatorPuzzle {
+    fn to_js(&self) -> Result<js::SimulatorPuzzle> {
+        Ok(js::SimulatorPuzzle {
+            puzzle_reveal: self.puzzle_reveal.to_js()?,
+            puzzle_hash: self.puzzle_hash.to_js()?,
+        })
+    }
+}
+
 impl FromJs<js::CoinState> for rust::CoinState {
     fn from_js(value: js::CoinState) -> Result<Self> {
         Ok(Self {

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -159,7 +159,6 @@ impl ToJs<js::Coin> for rust::Coin {
     }
 }
 
-
 impl FromJs<js::SimulatorPuzzle> for rust::SimulatorPuzzle {
     fn from_js(value: js::SimulatorPuzzle) -> Result<Self> {
         Ok(Self {

--- a/src/js.rs
+++ b/src/js.rs
@@ -86,6 +86,13 @@ pub struct ServerCoin {
     pub memo_urls: Vec<String>,
 }
 
+#[napi(object)]
+/// Object returned by simulator_new_puzzle, containing both the puzzle hash and the puzzle reveal.
+pub struct SimulatorPuzzle {
+    pub puzzle_hash: Buffer,
+    pub puzzle_reveal: Buffer,
+}
+
 pub fn err<T>(error: T) -> napi::Error
 where
     T: ToString,

--- a/src/js.rs
+++ b/src/js.rs
@@ -93,6 +93,13 @@ pub struct SimulatorPuzzle {
     pub puzzle_reveal: Buffer,
 }
 
+#[napi(object)]
+pub struct BlsPair {
+    pub sk: Buffer,
+    pub pk: Buffer,
+    pub puzzle_hash: Buffer,
+}
+
 pub fn err<T>(error: T) -> napi::Error
 where
     T: ToString,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use chia::bls::{
 
 use chia::protocol::{
     Bytes as RustBytes, Bytes32 as RustBytes32, Coin as RustCoin, CoinSpend as RustCoinSpend,
-    CoinStateUpdate, NewPeakWallet, Program, ProtocolMessageTypes, SpendBundle as RustSpendBundle,
+    CoinStateUpdate, NewPeakWallet, ProtocolMessageTypes, SpendBundle as RustSpendBundle,
 };
 use chia::puzzles::{standard::StandardArgs, DeriveSynthetic, Proof as RustProof};
 use chia::traits::Streamable;
@@ -609,6 +609,46 @@ impl Peer {
                 let coin = sim.lock().await.mint_coin(puzzle_hash, amount).await;
                 coin.to_js()
             }
+            None => Err(js::err("Simulator is not available for this peer type")),
+        }
+    }
+
+    #[napi]
+    /// Gets the current height of the simulator.
+    ///
+    /// @returns {Promise<u32>} The current height.
+    pub async fn simulator_height(&self) -> napi::Result<u32> {
+        match &self.sim {
+            Some(sim) => Ok(sim.lock().await.height().await),
+            None => Err(js::err("Simulator is not available for this peer type")),
+        }
+    }
+
+    #[napi]
+    /// Gets the coin state for a given coin ID.
+    ///
+    /// @param {Buffer} coinId - The coin ID to look up.
+    /// @returns {Promise<CoinState | null>} The coin state if found.
+    pub async fn simulator_coin_state(&self, coin_id: Buffer) -> napi::Result<Option<CoinState>> {
+        let coin_id = RustBytes32::from_js(coin_id)?;
+
+        match &self.sim {
+            Some(sim) => match sim.lock().await.coin_state(coin_id).await {
+                Some(state) => Ok(Some(state.to_js()?)),
+                None => Ok(None),
+            },
+            None => Err(js::err("Simulator is not available for this peer type")),
+        }
+    }
+
+    #[napi]
+    /// Gets the header hash at the specified height.
+    ///
+    /// @param {u32} height - The height to get the header hash for.
+    /// @returns {Promise<Buffer>} The header hash.
+    pub async fn header_hash(&self, height: u32) -> napi::Result<Buffer> {
+        match &self.sim {
+            Some(sim) => sim.lock().await.header_hash(height).await.to_js(),
             None => Err(js::err("Simulator is not available for this peer type")),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,15 +12,14 @@ use chia::bls::{
 };
 
 use chia::protocol::{
-    Bytes as RustBytes, Bytes32 as RustBytes32, Coin as RustCoin, CoinSpend as RustCoinSpend,
-    CoinStateUpdate, NewPeakWallet, ProtocolMessageTypes, SpendBundle as RustSpendBundle,
+    Bytes as RustBytes, Bytes32 as RustBytes32, Coin as RustCoin, CoinSpend as RustCoinSpend, CoinStateUpdate, NewPeakWallet, Program, ProtocolMessageTypes, SpendBundle as RustSpendBundle
 };
 use chia::puzzles::{standard::StandardArgs, DeriveSynthetic, Proof as RustProof};
 use chia::traits::Streamable;
 use chia_wallet_sdk::client::{
     connect_peer, create_native_tls_connector, load_ssl_cert, Connector, PeerOptions,
 };
-use chia_wallet_sdk::test::PeerSimulator;
+use chia_wallet_sdk::test::{ PeerSimulator, to_puzzle };
 use chia_wallet_sdk::types::{MAINNET_CONSTANTS, TESTNET11_CONSTANTS};
 use chia_wallet_sdk::utils::Address;
 use chia_wallet_sdk::{
@@ -460,7 +459,9 @@ pub struct Peer {
     inner: Arc<RustPeer>,
     peak: Arc<Mutex<Option<NewPeakWallet>>>,
     coin_listeners: Arc<Mutex<HashMap<RustBytes32, UnboundedSender<()>>>>,
+    sim: Option<Arc<Mutex<PeerSimulator>>>,
 }
+
 
 #[napi]
 #[derive(PartialEq, Eq)]
@@ -491,11 +492,13 @@ impl Peer {
     /// @returns {Promise<Peer>} A new Peer instance.
     pub async fn new(node_uri: String, peer_type: PeerType, tls: &Tls) -> napi::Result<Self> {
         let (peer, mut receiver);
+        let sim: Option<Arc<Mutex<PeerSimulator>>>;
         if peer_type == PeerType::Simulator {
-            let sim = PeerSimulator::new().await.map_err(js::err)?;
-            let (p, r) = sim.connect_raw().await.map_err(js::err)?;
+            let simulator = PeerSimulator::new().await.map_err(js::err)?;
+            let (p, r) = simulator.connect_raw().await.map_err(js::err)?;
             peer = p;
             receiver = r;
+            sim = Some(Arc::new(Mutex::new(simulator)));
         } else {
             let (p, r) = connect_peer(
                 peer_type.as_str().to_string(),
@@ -511,6 +514,7 @@ impl Peer {
             .map_err(js::err)?;
             peer = p;
             receiver = r;
+            sim = None;
         }
 
         let inner = Arc::new(peer);
@@ -555,6 +559,7 @@ impl Peer {
             inner,
             peak,
             coin_listeners,
+            sim,
         })
     }
 
@@ -583,6 +588,38 @@ impl Peer {
         .into();
 
         resp.to_js()
+    }
+
+    #[napi]
+    /// Creates a new coin with the specified puzzle hash and amount using the simulator.
+    ///
+    /// @param {Buffer} puzzleHash - The puzzle hash for the new coin.
+    /// @param {BigInt} amount - The amount for the new coin.
+    /// @returns {Promise<Coin>} The newly created coin.
+    pub async fn simulator_new_coin(&self, puzzle_hash: Buffer, amount: BigInt) -> napi::Result<Coin> {
+        let puzzle_hash = RustBytes32::from_js(puzzle_hash)?;
+        let amount = u64::from_js(amount)?;
+        match &self.sim {
+            Some(sim) => {
+                let coin = sim.lock().await.mint_coin(puzzle_hash, amount).await;
+                coin.to_js()
+            },
+            None => Err(js::err("Simulator is not available for this peer type")),
+        }
+    }
+
+    #[napi]
+    /// Creates a new puzzle and its hash using the simulator.
+    ///
+    /// @param {BigInt} value - The value to use for the puzzle.
+    /// @returns {Promise<js::SimulatorPuzzle>} The puzzle hash and reveal.
+    pub async fn simulator_new_puzzle(&self, value: BigInt) -> napi::Result<js::SimulatorPuzzle> {
+        let value = u64::from_js(value)?;
+        let (puzzle_hash, puzzle_reveal) = to_puzzle(value).map_err(js::err)?;
+        Ok(js::SimulatorPuzzle {
+            puzzle_hash: puzzle_hash.to_js()?,
+            puzzle_reveal: puzzle_reveal.to_js()?,
+        })
     }
 
     #[napi]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ use chia::bls::{
 };
 
 use chia::protocol::{
-    Bytes as RustBytes, Bytes32 as RustBytes32, Coin as RustCoin, CoinSpend as RustCoinSpend, CoinStateUpdate, NewPeakWallet, Program, ProtocolMessageTypes, SpendBundle as RustSpendBundle
+    Bytes as RustBytes, Bytes32 as RustBytes32, Coin as RustCoin, CoinSpend as RustCoinSpend,
+    CoinStateUpdate, NewPeakWallet, Program, ProtocolMessageTypes, SpendBundle as RustSpendBundle,
 };
 use chia::puzzles::{standard::StandardArgs, DeriveSynthetic, Proof as RustProof};
 use chia::traits::Streamable;
@@ -20,7 +21,7 @@ use chia_wallet_sdk::client::{
     connect_peer, create_native_tls_connector, load_ssl_cert, Connector, PeerOptions,
 };
 use chia_wallet_sdk::prelude::AggSigMe;
-use chia_wallet_sdk::test::{ to_program, to_puzzle, PeerSimulator };
+use chia_wallet_sdk::test::{to_program, to_puzzle, PeerSimulator};
 use chia_wallet_sdk::types::{MAINNET_CONSTANTS, TESTNET11_CONSTANTS};
 use chia_wallet_sdk::utils::Address;
 use chia_wallet_sdk::{
@@ -463,7 +464,6 @@ pub struct Peer {
     sim: Option<Arc<Mutex<PeerSimulator>>>,
 }
 
-
 #[napi]
 #[derive(PartialEq, Eq)]
 pub enum PeerType {
@@ -597,55 +597,20 @@ impl Peer {
     /// @param {Buffer} puzzleHash - The puzzle hash for the new coin.
     /// @param {BigInt} amount - The amount for the new coin.
     /// @returns {Promise<Coin>} The newly created coin.
-    pub async fn simulator_new_coin(&self, puzzle_hash: Buffer, amount: BigInt) -> napi::Result<Coin> {
+    pub async fn simulator_new_coin(
+        &self,
+        puzzle_hash: Buffer,
+        amount: BigInt,
+    ) -> napi::Result<Coin> {
         let puzzle_hash = RustBytes32::from_js(puzzle_hash)?;
         let amount = u64::from_js(amount)?;
         match &self.sim {
             Some(sim) => {
                 let coin = sim.lock().await.mint_coin(puzzle_hash, amount).await;
                 coin.to_js()
-            },
+            }
             None => Err(js::err("Simulator is not available for this peer type")),
         }
-    }
-
-    #[napi]
-    /// Creates a new puzzle and its hash using the simulator.
-    ///
-    /// @param {BigInt} value - The value to use for the puzzle.
-    /// @returns {Promise<js::SimulatorPuzzle>} The puzzle hash and reveal.
-    pub async fn simulator_new_puzzle(&self, value: BigInt) -> napi::Result<js::SimulatorPuzzle> {
-        let value = u64::from_js(value)?;
-        let (puzzle_hash, puzzle_reveal) = to_puzzle(value).map_err(js::err)?;
-        Ok(js::SimulatorPuzzle {
-            puzzle_hash: puzzle_hash.to_js()?,
-            puzzle_reveal: puzzle_reveal.to_js()?,
-        })
-    }
-
-    #[napi]
-    /// Creates a new BlsPair.
-    ///
-    /// @param {BigInt} value - The value to use to initialize the pair.
-    /// @returns {Promise<js::BlsPair>} The BlsPair.
-    pub fn simulator_new_blspair(&self, value: BigInt) -> napi::Result<js::BlsPair> {
-        let value = u64::from_js(value)?;
-        let pair = chia_wallet_sdk::test::BlsPair::new(value);
-        Ok(js::BlsPair {
-            puzzle_hash: pair.puzzle_hash.to_js()?,
-            sk: pair.sk.to_js()?,
-            pk: pair.pk.to_js()?,
-        })
-    }
-
-    #[napi]
-    /// Creates a new simulator program.
-    ///
-    /// @returns {Promise<Buffer>} The program.
-    pub fn simulator_new_program(&self, pk: Buffer) -> napi::Result<Buffer> {
-        let pk = RustPublicKey::from_js(pk)?;
-        let program = to_program([AggSigMe::new(pk, b"Hello, world!".to_vec().into())]).map_err(js::err)?;
-        Ok(program.to_js()?)
     }
 
     #[napi]
@@ -1571,4 +1536,44 @@ pub fn get_mainnet_genesis_challenge() -> napi::Result<Buffer> {
 /// @returns {Buffer} The testnet11 genesis challenge.
 pub fn get_testnet11_genesis_challenge() -> napi::Result<Buffer> {
     TESTNET11_CONSTANTS.genesis_challenge.to_js()
+}
+
+#[napi]
+/// Creates a new puzzle and its hash using the simulator.
+///
+/// @param {BigInt} value - The value to use for the puzzle.
+/// @returns {Promise<js::SimulatorPuzzle>} The puzzle hash and reveal.
+pub async fn simulator_new_puzzle(value: BigInt) -> napi::Result<js::SimulatorPuzzle> {
+    let value = u64::from_js(value)?;
+    let (puzzle_hash, puzzle_reveal) = to_puzzle(value).map_err(js::err)?;
+    Ok(js::SimulatorPuzzle {
+        puzzle_hash: puzzle_hash.to_js()?,
+        puzzle_reveal: puzzle_reveal.to_js()?,
+    })
+}
+
+#[napi]
+/// Creates a new BlsPair.
+///
+/// @param {BigInt} value - The value to use to initialize the pair.
+/// @returns {Promise<js::BlsPair>} The BlsPair.
+pub fn simulator_new_blspair(value: BigInt) -> napi::Result<js::BlsPair> {
+    let value = u64::from_js(value)?;
+    let pair = chia_wallet_sdk::test::BlsPair::new(value);
+    Ok(js::BlsPair {
+        puzzle_hash: pair.puzzle_hash.to_js()?,
+        sk: pair.sk.to_js()?,
+        pk: pair.pk.to_js()?,
+    })
+}
+
+#[napi]
+/// Creates a new simulator program.
+///
+/// @returns {Promise<Buffer>} The program.
+pub fn simulator_new_program(pk: Buffer) -> napi::Result<Buffer> {
+    let pk = RustPublicKey::from_js(pk)?;
+    let program =
+        to_program([AggSigMe::new(pk, b"Hello, world!".to_vec().into())]).map_err(js::err)?;
+    Ok(program.to_js()?)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use chia::traits::Streamable;
 use chia_wallet_sdk::client::{
     connect_peer, create_native_tls_connector, load_ssl_cert, Connector, PeerOptions,
 };
-use chia_wallet_sdk::test::{ PeerSimulator, to_puzzle };
+use chia_wallet_sdk::test::{ to_puzzle, PeerSimulator };
 use chia_wallet_sdk::types::{MAINNET_CONSTANTS, TESTNET11_CONSTANTS};
 use chia_wallet_sdk::utils::Address;
 use chia_wallet_sdk::{
@@ -619,6 +619,21 @@ impl Peer {
         Ok(js::SimulatorPuzzle {
             puzzle_hash: puzzle_hash.to_js()?,
             puzzle_reveal: puzzle_reveal.to_js()?,
+        })
+    }
+
+    #[napi]
+    /// Creates a new BlsPair.
+    ///
+    /// @param {BigInt} value - The value to use to initialize the pair.
+    /// @returns {Promise<js::BlsPair>} The BlsPair.
+    pub fn simulator_new_blspair(&self, value: BigInt) -> napi::Result<js::BlsPair> {
+        let value = u64::from_js(value)?;
+        let pair = chia_wallet_sdk::test::BlsPair::new(value);
+        Ok(js::BlsPair {
+            puzzle_hash: pair.puzzle_hash.to_js()?,
+            sk: pair.sk.to_js()?,
+            pk: pair.pk.to_js()?,
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@ use chia::traits::Streamable;
 use chia_wallet_sdk::client::{
     connect_peer, create_native_tls_connector, load_ssl_cert, Connector, PeerOptions,
 };
-use chia_wallet_sdk::test::{ to_puzzle, PeerSimulator };
+use chia_wallet_sdk::prelude::AggSigMe;
+use chia_wallet_sdk::test::{ to_program, to_puzzle, PeerSimulator };
 use chia_wallet_sdk::types::{MAINNET_CONSTANTS, TESTNET11_CONSTANTS};
 use chia_wallet_sdk::utils::Address;
 use chia_wallet_sdk::{
@@ -635,6 +636,16 @@ impl Peer {
             sk: pair.sk.to_js()?,
             pk: pair.pk.to_js()?,
         })
+    }
+
+    #[napi]
+    /// Creates a new simulator program.
+    ///
+    /// @returns {Promise<Buffer>} The program.
+    pub fn simulator_new_program(&self, pk: Buffer) -> napi::Result<Buffer> {
+        let pk = RustPublicKey::from_js(pk)?;
+        let program = to_program([AggSigMe::new(pk, b"Hello, world!".to_vec().into())]).map_err(js::err)?;
+        Ok(program.to_js()?)
     }
 
     #[napi]

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -22,3 +22,8 @@ impl From<UnspentCoinStates> for UnspentCoinsResponse {
         }
     }
 }
+
+pub struct SimulatorPuzzle {
+    pub puzzle_hash: Bytes32,
+    pub puzzle_reveal: Program,
+}

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1,5 +1,6 @@
 pub use crate::server_coin::ServerCoin;
 use crate::UnspentCoinStates;
+use chia::bls::{PublicKey, SecretKey};
 pub use chia::protocol::*;
 pub use chia::puzzles::{EveProof, LineageProof, Proof};
 
@@ -26,4 +27,10 @@ impl From<UnspentCoinStates> for UnspentCoinsResponse {
 pub struct SimulatorPuzzle {
     pub puzzle_hash: Bytes32,
     pub puzzle_reveal: Program,
+}
+
+pub struct BlsPair {
+    pub sk: SecretKey,
+    pub pk: PublicKey,
+    pub puzzle_hash: Bytes32,
 }


### PR DESCRIPTION
Exposed 1 new method in the peer class:

* sim.simulator_new_coin - if the peer was instantiated as a simulator we can call the simulator new coin

And 3 new helper methods to generate needed structures for tests:

* simulator_new_program
* simulator_new_blspair
* simulator_new_puzzle

These are helper methods in the  chia-wallet-sdk test crate ([example](https://github.com/xch-dev/chia-wallet-sdk/blob/main/crates/chia-sdk-test/src/simulator.rs#L76-L88))
