### PR TITLE
1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "datalayer-driver"
-version = "0.1.50"
+version = "1.0.0"
 dependencies = [
  "chia",
  "chia-puzzles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "napi"]
 [package]
 edition = "2021"
 name = "datalayer-driver"
-version = "0.1.50"
+version = "1.0.0"
 license = "MIT"
 authors = ["yakuhito <y@kuhi.to>"]
 homepage = "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/npm/darwin-arm64/package.json
+++ b/napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-darwin-arm64",
-  "version": "0.1.50",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/npm/darwin-x64/package.json
+++ b/napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-darwin-x64",
-  "version": "0.1.50",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/npm/linux-arm64-gnu/package.json
+++ b/napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-linux-arm64-gnu",
-  "version": "0.1.50",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/npm/linux-x64-gnu/package.json
+++ b/napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-linux-x64-gnu",
-  "version": "0.1.50",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/npm/win32-x64-msvc/package.json
+++ b/napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-win32-x64-msvc",
-  "version": "0.1.50",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver",
-  "version": "0.1.50",
+  "version": "1.0.0",
   "main": "index.js",
   "types": "index.d.ts",
   "repository": {


### PR DESCRIPTION
This release contains the breaking changes from #25 

Notable changes include updates to the rust api to remove redundant '_rust' suffixes from library API functionnames, as well as updating the driver to use v0.29 of the [chia-wallet-sdk](https://github.com/xch-dev/chia-wallet-sdk).