### PR TITLE
1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "datalayer-driver"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chia",
  "chia-puzzles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "napi"]
 [package]
 edition = "2021"
 name = "datalayer-driver"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = ["yakuhito <y@kuhi.to>"]
 homepage = "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/npm/darwin-arm64/package.json
+++ b/napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-darwin-arm64",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/npm/darwin-x64/package.json
+++ b/napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-darwin-x64",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/npm/linux-arm64-gnu/package.json
+++ b/napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-linux-arm64-gnu",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/npm/linux-x64-gnu/package.json
+++ b/napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-linux-x64-gnu",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/npm/win32-x64-msvc/package.json
+++ b/napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver-win32-x64-msvc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/DIG-Network/DataLayer-Driver"

--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dignetwork/datalayer-driver",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "types": "index.d.ts",
   "repository": {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -723,6 +723,7 @@ pub async fn get_store_creation_height(
         .ok_or(WalletError::UnknownCoin)
 }
 
+#[derive(Clone, Debug)]
 pub enum DataStoreInnerSpend {
     Owner(PublicKey),
     Admin(PublicKey),


### PR DESCRIPTION
the tiniest of releases. derive debug and clone for the `DataStoreInnerSpend` enum