### PR TITLE
feat!: migrate to chia-wallet-sdk 0.34 family (chia-protocol 0.36, clvmr 0.16)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,7 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |
               set -e &&
-              cd /build && cargo update -p base64ct --precise 1.6.0 || true &&
+              rustup update stable && rustup default stable &&
               cd /build/napi && npm install && npm run build -- --target x86_64-unknown-linux-gnu &&
               strip /build/napi/*.node
           - host: macos-latest
@@ -73,7 +73,7 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
             build: |
               set -e &&
-              cd /build && cargo update -p base64ct --precise 1.6.0 || true &&
+              rustup update stable && rustup default stable &&
               cd /build/napi && npm install && npm run build -- --target aarch64-unknown-linux-gnu
     name: stable - ${{ matrix.settings.target }} - node@20
     runs-on: ${{ matrix.settings.host }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 4.0.0 (WIP)
+
+- Migrate chia-wallet-sdk 0.30 -> 0.34 family (dig_ecosystem#2133).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
-## 4.0.0 (WIP)
+## 4.0.0
 
-- Migrate chia-wallet-sdk 0.30 -> 0.34 family (dig_ecosystem#2133).
+- Migrate the chia-family dependencies from the 0.30 to the 0.34 family
+  (dig_ecosystem#2133): `chia-wallet-sdk` 0.34.0, `chia-protocol` 0.36.1,
+  `chia-puzzles` 0.20.3, `clvm-traits` 0.36.1, `clvmr` 0.16.2.
+- Replace the `chia` umbrella crate (which has no release depending on
+  chia-protocol 0.36.x) with the individual `chia-protocol`, `chia-bls`,
+  `chia-consensus`, `chia-traits` and `clvm-utils` sub-crates.
+- Puzzle Rust types (`Proof`, `EveProof`, `LineageProof`, `cat`, `nft`,
+  `standard`, `DeriveSynthetic`) moved from `chia-puzzles` to the new
+  `chia-puzzle-types` crate; `SINGLETON_LAUNCHER_HASH` and other bytecode
+  constants remain in `chia-puzzles`.
+- `chia_consensus::solution_generator` now returns
+  `chia_consensus::error::Error` instead of `std::io::Error`; the `WalletError`
+  `Io` variant is replaced by a `Consensus` variant.
+- Add a peer-simulator custody KAT pinning `DataStore::from_spend`'s owner-melt
+  signal (`Err(DriverError::MissingChild)`), verified unchanged under 0.34.
+
+BREAKING CHANGE: the public chia-family dependency versions changed (major bump).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +152,26 @@ name = "binascii"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bip39"
@@ -194,20 +220,20 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -242,9 +268,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.40"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -257,35 +283,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
-name = "chia"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27699b864f74bfe17216295e445db63f1aedbe3be9560833009a5890ce5d46d"
-dependencies = [
- "chia-bls 0.26.0",
- "chia-client",
- "chia-consensus",
- "chia-protocol",
- "chia-puzzle-types",
- "chia-secp",
- "chia-serde",
- "chia-sha2 0.26.0",
- "chia-ssl",
- "chia-traits 0.26.0",
- "clvm-traits",
- "clvm-utils",
- "clvmr",
-]
-
-[[package]]
 name = "chia-bls"
-version = "0.22.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86eaaa00a83a7511e8eb74ccb1ebe4358d927f43e06d45da5350e19ef2df1ca"
+checksum = "38840e8c8c5c6eb61304d85102230e74c2015c2bfb945292777f83f48915544c"
 dependencies = [
  "blst",
- "chia-sha2 0.22.0",
- "chia-traits 0.22.0",
+ "chia-sha2 0.28.2",
+ "chia-traits 0.28.2",
  "hex",
  "hkdf",
  "linked-hash-map",
@@ -295,14 +300,14 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.26.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9ac7e90ae816e814dc26fb332615a5449d1d26e965eb7ad068ae530f9c3c7b"
+checksum = "4f02cbfd038d9050d45edbe8f38e09391c73479c0cca5b37925daf48c4d4fcd4"
 dependencies = [
  "blst",
  "chia-serde",
- "chia-sha2 0.26.0",
- "chia-traits 0.26.0",
+ "chia-sha2 0.36.1",
+ "chia-traits 0.36.1",
  "hex",
  "hkdf",
  "linked-hash-map",
@@ -312,34 +317,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "chia-client"
-version = "0.26.0"
+name = "chia-bls"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3874f2e4c87f246457a42890d4f8e0cae9d019131b54f80f66c561c8d05cd444"
+checksum = "48f85777c396aa0ed9837add53ef22fe6b153d861b8a344dd57a4d493dd6c5c4"
 dependencies = [
- "chia-protocol",
- "chia-traits 0.26.0",
- "futures-util",
- "thiserror 1.0.69",
- "tokio",
- "tokio-tungstenite",
- "tungstenite",
+ "blst",
+ "chia-sha2 0.42.1",
+ "chia-traits 0.42.1",
+ "hex",
+ "hkdf",
+ "linked-hash-map",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "chia-consensus"
-version = "0.26.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481208db317ed106dc249a5669a6916c565374633850584480a40b639409a940"
+checksum = "d942bcb20b243213becbd94630dd7122c18dea7450beab38cbb4a6fcac993cae"
 dependencies = [
- "chia-bls 0.26.0",
+ "chia-bls 0.36.1",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
- "chia-sha2 0.26.0",
- "chia-traits 0.26.0",
- "chia_streamable_macro 0.26.0",
- "clvm-traits",
+ "chia-sha2 0.36.1",
+ "chia-traits 0.36.1",
+ "chia_streamable_macro 0.36.1",
+ "clvm-traits 0.36.1",
  "clvm-utils",
  "clvmr",
  "hex",
@@ -349,33 +355,34 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol"
-version = "0.26.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9256179e4c912313532d7a47a50f67f6128313ee86a3798e54050afb73d6042"
+checksum = "150d1f8a5978fe58bce49af89ef2abfd292dad324fcbbced5972de78772f6e9c"
 dependencies = [
- "chia-bls 0.26.0",
+ "chia-bls 0.36.1",
  "chia-serde",
- "chia-sha2 0.26.0",
- "chia-traits 0.26.0",
- "chia_streamable_macro 0.26.0",
- "clvm-traits",
+ "chia-sha2 0.36.1",
+ "chia-traits 0.36.1",
+ "chia_streamable_macro 0.36.1",
+ "clvm-traits 0.36.1",
  "clvm-utils",
  "clvmr",
  "hex",
  "serde",
+ "serde_arrays",
 ]
 
 [[package]]
 name = "chia-puzzle-types"
-version = "0.26.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239406b55be27d99a6903057e6785e0279fe9fdc48270faf7ef9270dcfa05c8d"
+checksum = "37af8b2e82a898e35eea5e2766d18d616ab266343fa567042b6217bd96ef4819"
 dependencies = [
- "chia-bls 0.26.0",
+ "chia-bls 0.36.1",
  "chia-protocol",
  "chia-puzzles",
- "chia-sha2 0.26.0",
- "clvm-traits",
+ "chia-sha2 0.36.1",
+ "clvm-traits 0.36.1",
  "clvm-utils",
  "clvmr",
  "hex-literal",
@@ -384,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "chia-puzzles"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a14a89cf37b36585609bfb0a9cc45e4d4bdd32181ccc8f7c730591f20c73d66"
+checksum = "553363ce9550cfde0ae1306a0a79bf9afd36ea09e0222b874b6287b44ad9d178"
 dependencies = [
  "hex",
  "hex-literal",
@@ -394,14 +401,14 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-client"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a9ab7609f5c98ff34fc5ba33ad50bfdecca771165640eb88e8054ccef18916"
+checksum = "a8b56f14dfd5ce188bece4d0c3478d0dc9fee15f3b83e1b34aa910861e61f4b8"
 dependencies = [
  "chia-protocol",
  "chia-sdk-types",
  "chia-ssl",
- "chia-traits 0.26.0",
+ "chia-traits 0.36.1",
  "futures-util",
  "native-tls",
  "thiserror 2.0.17",
@@ -413,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-coinset"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb55e723e4b847fdbb9e729fef1a0f21c624b618bda8a17c9c205ff9db64a1e1"
+checksum = "02175bf3670878f6c43fcd4497c9b7b9d8e3cf43d90dff625997db50a3d71778"
 dependencies = [
  "chia-protocol",
  "hex",
@@ -426,10 +433,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "chia-sdk-derive"
-version = "0.30.0"
+name = "chia-sdk-daemon"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add9e60902df26dfe987d87f1b19ab7e359c6269fa4f222a9d79c02a9dba969d"
+checksum = "b44f9008f55d605ab688e239d8303e6240beca329d27838e0ad6340422bef13a"
+dependencies = [
+ "chia-sdk-client",
+ "chia-sdk-coinset",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tungstenite",
+]
+
+[[package]]
+name = "chia-sdk-derive"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9e366cbc576221da519a08544b546cbf0441a4d3e8bbd8e69f3a06480a6af4"
 dependencies = [
  "convert_case 0.8.0",
  "quote",
@@ -438,63 +463,68 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-driver"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260c97751f8986e7f82091e3bee504044efb79857f26bfcd2b5d37cba674f79e"
+checksum = "bb2677cf560410db034c8bb5de1e07dec2021b12fd986981390654e260a2b856"
 dependencies = [
  "bigdecimal",
  "bip39",
- "chia-bls 0.26.0",
+ "chia-bls 0.36.1",
  "chia-consensus",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
  "chia-sdk-signer",
  "chia-sdk-types",
+ "chia-sdk-utils",
  "chia-secp",
- "chia-sha2 0.26.0",
- "chia-traits 0.26.0",
- "chia_streamable_macro 0.26.0",
- "clvm-traits",
+ "chia-sha2 0.36.1",
+ "chia-traits 0.36.1",
+ "chia_streamable_macro 0.36.1",
+ "clvm-traits 0.36.1",
  "clvm-utils",
  "clvmr",
- "getrandom 0.2.16",
+ "flate2",
+ "getrandom 0.3.4",
  "hex",
  "hex-literal",
  "indexmap",
  "num-bigint",
- "rand",
- "rand_chacha",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "chia-sdk-signer"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71037389cc3bdebc47c9c6cfebc898244393e4e7246b486d64922a9c23bbac6"
+checksum = "83f8553345d14f9eb89f07df0d3854162d818d21acf27140997ae77256dc7883"
 dependencies = [
- "chia-bls 0.26.0",
+ "chia-bls 0.36.1",
  "chia-consensus",
  "chia-protocol",
  "chia-sdk-types",
  "chia-secp",
- "chia-sha2 0.26.0",
- "clvm-traits",
+ "chia-sha2 0.36.1",
+ "clvm-traits 0.36.1",
  "clvmr",
+ "colored",
  "k256",
+ "rue-lir",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "chia-sdk-test"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365b95611176b670cd61455ce6578cccf740a66b7d27cd3b31395c12f4073bc2"
+checksum = "de32a1cc7124f151401d553413d45b88b607dbfa69cf1721c7daab75b717d1a2"
 dependencies = [
  "anyhow",
+ "bincode",
  "bip39",
- "chia-bls 0.26.0",
+ "chia-bls 0.36.1",
  "chia-consensus",
  "chia-protocol",
  "chia-puzzle-types",
@@ -502,22 +532,21 @@ dependencies = [
  "chia-sdk-signer",
  "chia-sdk-types",
  "chia-secp",
- "chia-sha2 0.26.0",
- "chia-traits 0.26.0",
- "clvm-traits",
+ "chia-sha2 0.36.1",
+ "chia-traits 0.36.1",
+ "clvm-traits 0.36.1",
  "clvm-utils",
  "clvmr",
  "futures-channel",
  "futures-util",
  "hex",
  "indexmap",
- "itertools",
+ "itertools 0.13.0",
  "prettytable-rs",
- "rand",
- "rand_chacha",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
  "serde",
- "serde_json",
- "signature",
+ "signature 2.2.0",
  "thiserror 2.0.17",
  "tokio",
  "tokio-tungstenite",
@@ -526,47 +555,51 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-types"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298b92f005cd884861678808813cb49dca3545231b6b442d691e01535ed86825"
+checksum = "0891df37e7b053682b7bec452321d0b2205c20de8792e96470d571390cfd5b48"
 dependencies = [
- "chia-bls 0.26.0",
+ "chia-bls 0.36.1",
  "chia-consensus",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
  "chia-sdk-derive",
  "chia-secp",
- "chia-sha2 0.26.0",
- "clvm-traits",
+ "chia-sha2 0.36.1",
+ "chialisp",
+ "clvm-traits 0.36.1",
  "clvm-utils",
- "clvm_tools_rs",
  "clvmr",
  "hex-literal",
+ "rue-compiler",
+ "rue-lir",
+ "rue-options",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "chia-sdk-utils"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738bc2a53dcece78184aca4de617df666e984af0c86560131213039889d927fc"
+checksum = "b7831343041ceb5f170ef4ff8d8c2b91c055ab75f8a8e075e8bef2c423a0c47c"
 dependencies = [
  "bech32",
  "chia-protocol",
+ "hex",
  "indexmap",
- "rand",
- "rand_chacha",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "chia-secp"
-version = "0.26.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae00dfc70f7a3b20c5074ea3684b25f7b64225ad44ca3ea766b4e908f86c2d5"
+checksum = "b8fc00f8ad264eb260fd69fe2c7cb10c45b0a0699765e8ed8eac9be064ba3b55"
 dependencies = [
- "chia-sha2 0.26.0",
+ "chia-sha2 0.36.1",
  "hex",
  "k256",
  "p256",
@@ -574,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "chia-serde"
-version = "0.26.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b013e263888739bfecf7456552eb4a9f2260f920db8b46b0723fb553ab1e030"
+checksum = "f776d8555d463e6915e02598bb2be2123c57f6eaeb5c8078565957f062b92d1d"
 dependencies = [
  "hex",
  "serde",
@@ -584,84 +617,122 @@ dependencies = [
 
 [[package]]
 name = "chia-sha2"
-version = "0.22.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7b37c5362dfb1c9449902139e94a91bbd8d3773c13939972fd88e4f14c4f9d"
+checksum = "d2f03c71bc63599a711caad15dafca1d2a948c26b4c8a021709a338149632769"
 dependencies = [
  "sha2 0.10.9",
 ]
 
 [[package]]
 name = "chia-sha2"
-version = "0.26.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3ab374b1f248d87516c34e4c128a91d2086e76a46bb44e386c96a71ea39129"
+checksum = "f06500dc809a916fa0c70f5219b8b79a598462382a4ddca91ef1a3cb32b826ce"
+dependencies = [
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "chia-sha2"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0934b0d6b878f29ba6c958e56e4b7158f9e687c200ffdca141dbc408a5cce42e"
+dependencies = [
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "chia-sha2"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eabeed0e07a8656ff9e7597988eb21b48af6a1997dfca47164dd1544c80fcba"
 dependencies = [
  "sha2 0.10.9",
 ]
 
 [[package]]
 name = "chia-ssl"
-version = "0.26.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51af8606c8376d730d6607cb69fe5edd87f5d0d106e5620065f58a31e7f348a4"
+checksum = "94f5dbc9f086368e7a7f819322e74e7e445bfd757540874ede4284a0c84b1a13"
 dependencies = [
- "rand",
+ "getrandom 0.4.3",
  "rcgen",
  "rsa",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "time",
 ]
 
 [[package]]
 name = "chia-traits"
-version = "0.22.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340ad823ef953d2ab9f937deae99b04bab73c0bf1a6aea1353331a5f875192e0"
+checksum = "52463c56cdf35aac55ecb35ffc0a615f0780f33f144503957e83f5b1ad92da3c"
 dependencies = [
- "chia-sha2 0.22.0",
- "chia_streamable_macro 0.22.0",
+ "chia-sha2 0.28.2",
+ "chia_streamable_macro 0.28.2",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "chia-traits"
-version = "0.26.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440a88dfa8f685a87c4bae5f0b12c7bec1466ca1ff44dfc6b09acc605f7848fe"
+checksum = "1f4922b447b2d8418213948af1a448c3ca7b84e149b51b2c87a2e00e80bb19b0"
 dependencies = [
- "chia-sha2 0.26.0",
- "chia_streamable_macro 0.26.0",
+ "chia-sha2 0.36.1",
+ "chia_streamable_macro 0.36.1",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "chia-wallet-sdk"
-version = "0.30.0"
+name = "chia-traits"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94547c50b141ad9ae84f9bcc26c0bf467b7570f0354c906fb203eeea69886a4c"
+checksum = "e012b4d5336fe5457be5157a655208a9671a41bd41c3fc72ac59c56073c21c18"
 dependencies = [
- "chia-bls 0.26.0",
+ "chia-sha2 0.42.1",
+ "chia_streamable_macro 0.42.1",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "chia-wallet-sdk"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d57cc9efa1f6f4cca48b38ec4ee461e2d06ccdc71abc9f422b6b0f4c4940732"
+dependencies = [
+ "chia-bls 0.36.1",
+ "chia-consensus",
  "chia-protocol",
+ "chia-puzzle-types",
+ "chia-puzzles",
  "chia-sdk-client",
  "chia-sdk-coinset",
+ "chia-sdk-daemon",
  "chia-sdk-driver",
  "chia-sdk-signer",
  "chia-sdk-test",
  "chia-sdk-types",
  "chia-sdk-utils",
- "clvm-traits",
+ "chia-secp",
+ "chia-serde",
+ "chia-sha2 0.36.1",
+ "chia-ssl",
+ "chia-traits 0.36.1",
+ "clvm-traits 0.36.1",
  "clvm-utils",
  "clvmr",
 ]
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.22.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed16ee21f14ed878cfc23b0354c8c6703190a5565d03625ea44324a3f21717f1"
+checksum = "cc6b807a9c04440d3f30b5534b84b462b996b34eee7fe0b7f8737ae6dfc6b9d4"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -669,61 +740,36 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.26.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068278c78a0c53786012f6330a088f3f6ffe83bd39cb8f21d308eeec2f43a3dc"
+checksum = "2b60cefc5fe39f695816d42a327cbefad3d6d6a8ecadad1b58d7507067c25da8"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "clvm-derive"
-version = "0.26.0"
+name = "chia_streamable_macro"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ded863cb5482335498872e91989487283f012adb7ca4ddf54ad7c6995058db"
+checksum = "9567c7e8fe38b640aeeb4af3c0e04f4f6938a438a2506b39bb93d39e0a23e1a9"
 dependencies = [
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "clvm-traits"
-version = "0.26.0"
+name = "chialisp"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469c44226c83de37509415482c89c00763f58de198844c34d2d62161b087d0ce"
-dependencies = [
- "chia-bls 0.26.0",
- "chia-secp",
- "clvm-derive",
- "clvmr",
- "num-bigint",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "clvm-utils"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5646cd8d02f9c55c76ef6ff7598df54e6c8361f27fe8c9122e3ae9ef55935fcd"
-dependencies = [
- "chia-sha2 0.26.0",
- "clvm-traits",
- "clvmr",
- "hex",
-]
-
-[[package]]
-name = "clvm_tools_rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00394d353154d726b10ca4f76056f4fac3ad37a3218c83ba3008b041e1398c3"
+checksum = "c991ea839bb6e2299bd3600b786381c4c1b08f6780800719a24c5d33157cb3e2"
 dependencies = [
  "binascii",
- "chia-bls 0.22.0",
+ "chia-bls 0.42.1",
  "clvmr",
  "do-notation",
  "getrandom 0.2.16",
@@ -739,7 +785,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.11.0",
  "tempfile",
  "unicode-segmentation",
  "wasm-bindgen",
@@ -747,15 +793,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "clvmr"
-version = "0.14.0"
+name = "clvm-derive"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6b7142674607f3a213addaf261bd70b07537297e460a9cc6a389068a62934f"
+checksum = "9d2f39856545faf48ae1e191b24fa0b74ff79e57b0b9d269a35d14282803d2b2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clvm-traits"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e74489df9233fdf7605d79032fe18f808ff33d7e69a9932db4c96ffd0e50e9"
+dependencies = [
+ "clvmr",
+ "num-bigint",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "clvm-traits"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96380e11b921106bd3d2e24f8b85b6de2f99a760a6d5f0bd6d68ec096695b34b"
+dependencies = [
+ "chia-bls 0.36.1",
+ "chia-secp",
+ "clvm-derive",
+ "clvmr",
+ "num-bigint",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "clvm-utils"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65adea81c7ab1659180a4ffb10a0df63eb049b5b8de2caa8bf2d762f55c7c4db"
+dependencies = [
+ "chia-sha2 0.36.1",
+ "clvm-traits 0.36.1",
+ "clvmr",
+ "hex",
+ "hex-literal",
+]
+
+[[package]]
+name = "clvmr"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2174ea916c818da7aa500ec9dfeb891b2510b160efb20deec292710df24844b"
 dependencies = [
  "bitvec",
  "bumpalo",
- "chia-bls 0.22.0",
- "chia-sha2 0.22.0",
+ "chia-bls 0.28.2",
+ "chia-sha2 0.34.0",
  "hex",
  "hex-literal",
  "k256",
@@ -764,9 +859,34 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "sha3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -774,6 +894,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -789,6 +915,15 @@ name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -810,6 +945,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,14 +966,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
  "zeroize",
 ]
 
@@ -838,6 +1017,25 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -872,6 +1070,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,12 +1086,17 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "datalayer-driver"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
- "chia",
+ "chia-bls 0.36.1",
+ "chia-consensus",
+ "chia-protocol",
+ "chia-puzzle-types",
  "chia-puzzles",
+ "chia-traits 0.36.1",
  "chia-wallet-sdk",
- "clvm-traits",
+ "clvm-traits 0.36.1",
+ "clvm-utils",
  "clvmr",
  "futures-util",
  "hex",
@@ -893,7 +1105,7 @@ dependencies = [
  "num-bigint",
  "openssl",
  "openssl-sys",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -902,7 +1114,11 @@ dependencies = [
 name = "datalayer-driver-napi"
 version = "0.1.0"
 dependencies = [
- "chia",
+ "chia-bls 0.36.1",
+ "chia-protocol",
+ "chia-puzzle-types",
+ "chia-puzzles",
+ "chia-traits 0.36.1",
  "chia-wallet-sdk",
  "datalayer-driver",
  "futures-util",
@@ -912,7 +1128,7 @@ dependencies = [
  "napi-derive",
  "openssl",
  "openssl-sys",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -923,8 +1139,19 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -944,20 +1171,31 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "powerfmt",
+ "derive_more-impl",
 ]
 
 [[package]]
-name = "digest"
-version = "0.9.0"
+name = "derive_more-impl"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "generic-array",
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -967,9 +1205,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1016,12 +1265,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1036,15 +1285,15 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468",
- "pkcs8",
- "rand_core",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1093,15 +1342,26 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.3"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "libz-sys",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1111,9 +1371,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1185,6 +1445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,20 +1485,32 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1254,32 +1532,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -1363,6 +1641,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1512,6 +1799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1833,8 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1596,6 +1891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,7 +1926,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1631,7 +1935,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1639,15 +1943,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -1676,6 +1977,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "cmake",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,9 +1997,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1727,6 +2041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1736,7 +2051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.59.0",
 ]
 
@@ -1851,23 +2166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,9 +2176,20 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-integer"
@@ -1920,7 +2229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1956,12 +2264,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -2053,6 +2355,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2375,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -2091,13 +2408,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.7.5"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2106,8 +2422,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2170,7 +2496,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.6+spec-1.1.0",
 ]
 
 [[package]]
@@ -2208,6 +2543,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,8 +2561,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+ "serde",
 ]
 
 [[package]]
@@ -2231,7 +2583,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+ "serde",
 ]
 
 [[package]]
@@ -2242,6 +2605,22 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+ "serde",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rcgen"
@@ -2279,9 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2291,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2302,9 +2681,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
@@ -2367,23 +2752,193 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.8"
+name = "rowan"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
 dependencies = [
- "const-oid",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash",
+ "text-size",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.5",
+ "crypto-primes",
+ "digest 0.11.3",
  "pkcs1",
- "pkcs8",
- "rand_core",
- "signature",
- "spki",
- "subtle",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "signature 3.0.0",
+ "spki 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rue-ast"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8feffcdd1f81db8d83980714cdd15d53608f7cc49e4d4a1c52d0fe1d523c4b"
+dependencies = [
+ "paste",
+ "rue-parser",
+]
+
+[[package]]
+name = "rue-compiler"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b58c388afe6e7fb78e63f43b455c57b6f788f1e2b65ae895e9ff38039ab2fdc"
+dependencies = [
+ "clvmr",
+ "hex",
+ "id-arena",
+ "indexmap",
+ "log",
+ "num-bigint",
+ "num-traits",
+ "rowan",
+ "rue-ast",
+ "rue-diagnostic",
+ "rue-hir",
+ "rue-lexer",
+ "rue-lir",
+ "rue-options",
+ "rue-parser",
+ "rue-types",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "rue-diagnostic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a953cccb3041f21c77e80ea8fdb03e7214b91195d939f3146f054e27020ea1a9"
+dependencies = [
+ "derive_more",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "rue-hir"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d73674bfcd164e453dbeabfa99cb952827abf7bc0540ed5bf6d2ccea97d06a"
+dependencies = [
+ "derive_more",
+ "hex",
+ "id-arena",
+ "indexmap",
+ "log",
+ "num-bigint",
+ "rue-diagnostic",
+ "rue-lir",
+ "rue-options",
+ "rue-types",
+]
+
+[[package]]
+name = "rue-lexer"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68345f23ba80d548d4a671de14e455de74ae58fccfa436db105b35308a1780ed"
+
+[[package]]
+name = "rue-lir"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099f3c3d6b432bb94cf8876b7f71b650d6887ae9193e8063c529feca37276b6f"
+dependencies = [
+ "chialisp",
+ "clvm-traits 0.28.1",
+ "clvmr",
+ "colored",
+ "id-arena",
+ "num-bigint",
+ "num-integer",
+ "sha2 0.10.9",
+ "sha3",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "rue-options"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f94c541b1397b7fbc4aaba36440c0bc11ddb703b024a424dd2fe193ec413b7"
+dependencies = [
+ "serde",
+ "thiserror 2.0.17",
+ "toml",
+]
+
+[[package]]
+name = "rue-parser"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d23577d98f535c02d2898e0a0e9cdf04b82d1ea91b15cd31e66141bce73c4c5"
+dependencies = [
+ "derive_more",
+ "indexmap",
+ "itertools 0.14.0",
+ "num-derive",
+ "num-traits",
+ "rowan",
+ "rue-diagnostic",
+ "rue-lexer",
+]
+
+[[package]]
+name = "rue-types"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6dc5f584d1ff7cf562737aa990d746def396ca4211c8f56c2d28d6dc00718b"
+dependencies = [
+ "clvmr",
+ "derive_more",
+ "hex",
+ "id-arena",
+ "indexmap",
+ "log",
+ "rstest",
+ "rue-diagnostic",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2391,6 +2946,21 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -2403,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -2456,10 +3026,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -2504,6 +3074,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_arrays"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a16b99c5ea4fe3daccd14853ad260ec00ea043b2708d1fd1da3106dcd8d9df"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +3116,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,27 +3137,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -2579,8 +3164,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2595,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2615,8 +3211,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2641,19 +3253,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -2713,12 +3329,12 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2734,6 +3350,12 @@ dependencies = [
  "rustversion",
  "winapi",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
@@ -2786,30 +3408,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2896,10 +3517,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2908,9 +3562,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0db3bae107c9522f86d361697dee1d7386a2ddcf659d5aea5159819a21a3c4a7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3007,7 +3688,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -3015,9 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -3036,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -3047,10 +3728,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -3089,6 +3782,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,15 +3801,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
 
 [[package]]
 name = "wasip2"
@@ -3334,6 +4024,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,6 @@ dependencies = [
  "chia-puzzles",
  "chia-sdk-signer",
  "chia-sdk-types",
- "chia-sdk-utils",
  "chia-secp",
  "chia-sha2 0.36.1",
  "chia-traits 0.36.1",
@@ -484,7 +483,6 @@ dependencies = [
  "clvm-traits 0.36.1",
  "clvm-utils",
  "clvmr",
- "flate2",
  "getrandom 0.3.4",
  "hex",
  "hex-literal",
@@ -866,15 +864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,15 +961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1351,17 +1331,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "libz-sys",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -1977,19 +1946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
-dependencies = [
- "cc",
- "cmake",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,7 +1997,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -3223,12 +3178,6 @@ dependencies = [
  "digest 0.11.3",
  "rand_core 0.10.1",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 name = "datalayer-driver"
 version = "4.0.0"
 dependencies = [
+ "anyhow",
  "chia-bls 0.36.1",
  "chia-consensus",
  "chia-protocol",
@@ -1117,7 +1118,6 @@ dependencies = [
  "chia-bls 0.36.1",
  "chia-protocol",
  "chia-puzzle-types",
- "chia-puzzles",
  "chia-traits 0.36.1",
  "chia-wallet-sdk",
  "datalayer-driver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ chia-puzzle-types = "0.36.1"
 thiserror = "1.0.61"
 clvmr = "0.16.2"
 tokio = "1.39.3"
-chia-wallet-sdk = { version = "0.34.0", features = ["chip-0035", "native-tls", "peer-simulator", "action-layer", "offer-compression"] }
+chia-wallet-sdk = { version = "0.34.0", features = ["chip-0035", "native-tls", "peer-simulator", "action-layer"] }
 hex-literal = "0.4.1"
 num-bigint = "0.4.6"
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ futures-util = "0.3"
 clvm-traits = "0.36.1"
 indexmap = "2.11.4"
 
+[dev-dependencies]
+anyhow = "1.0.86"
+
 [target.aarch64-unknown-linux-gnu.dependencies]
 openssl = { version = "0.10.64", features = ["vendored"] }
 openssl-sys = { version = "0.9.102", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "napi"]
 [package]
 edition = "2021"
 name = "datalayer-driver"
-version = "3.0.0"
+version = "4.0.0"
 license = "MIT"
 authors = ["yakuhito <y@kuhi.to>", "William Wills <wwills2@protonmail.com>"]
 homepage = "https://github.com/DIG-Network/DataLayer-Driver"
@@ -16,18 +16,23 @@ keywords = ["chia", "blockchain", "datalayer", "storage", "web3"]
 categories = ["cryptography::cryptocurrencies", "web-programming"]
 
 [dependencies]
-chia = "0.26.0"
-chia-puzzles = "0.20.1"
+chia-protocol = "0.36.1"
+chia-bls = "0.36.1"
+chia-consensus = "0.36.1"
+chia-traits = "0.36.1"
+clvm-utils = "0.36.1"
+chia-puzzles = "0.20.3"
+chia-puzzle-types = "0.36.1"
 thiserror = "1.0.61"
-clvmr = "0.14.0"
+clvmr = "0.16.2"
 tokio = "1.39.3"
-chia-wallet-sdk = { version = "0.30.0", features = ["chip-0035", "native-tls", "peer-simulator", "action-layer"] }
+chia-wallet-sdk = { version = "0.34.0", features = ["chip-0035", "native-tls", "peer-simulator", "action-layer", "offer-compression"] }
 hex-literal = "0.4.1"
 num-bigint = "0.4.6"
 hex = "0.4.3"
 rand = "0.8"
 futures-util = "0.3"
-clvm-traits = "0.26.0"
+clvm-traits = "0.36.1"
 indexmap = "2.11.4"
 
 [target.aarch64-unknown-linux-gnu.dependencies]

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -22,7 +22,6 @@ napi-derive = "2.12.2"
 # - Utilities (hex encoding, random selection)
 chia-protocol = "0.36.1"
 chia-bls = "0.36.1"
-chia-puzzles = "0.20.3"
 chia-puzzle-types = "0.36.1"
 chia-traits = "0.36.1"
 thiserror = "1.0.61"

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -20,10 +20,14 @@ napi-derive = "2.12.2"
 # - Error handling (thiserror)
 # - Async runtime (tokio, futures-util)
 # - Utilities (hex encoding, random selection)
-chia = "0.26.0"
+chia-protocol = "0.36.1"
+chia-bls = "0.36.1"
+chia-puzzles = "0.20.3"
+chia-puzzle-types = "0.36.1"
+chia-traits = "0.36.1"
 thiserror = "1.0.61"
 tokio = "1.39.3"
-chia-wallet-sdk = { version = "0.30.0", features = ["chip-0035", "native-tls", "peer-simulator", "action-layer"] }
+chia-wallet-sdk = { version = "0.34.0", features = ["chip-0035", "native-tls", "peer-simulator", "action-layer", "offer-compression"] }
 hex = "0.4.3"
 rand = "0.8"
 futures-util = "0.3"

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -26,7 +26,7 @@ chia-puzzle-types = "0.36.1"
 chia-traits = "0.36.1"
 thiserror = "1.0.61"
 tokio = "1.39.3"
-chia-wallet-sdk = { version = "0.34.0", features = ["chip-0035", "native-tls", "peer-simulator", "action-layer", "offer-compression"] }
+chia-wallet-sdk = { version = "0.34.0", features = ["chip-0035", "native-tls", "peer-simulator", "action-layer"] }
 hex = "0.4.3"
 rand = "0.8"
 futures-util = "0.3"

--- a/napi/src/conversions.rs
+++ b/napi/src/conversions.rs
@@ -1,7 +1,5 @@
-use chia::{
-    bls::{PublicKey, SecretKey, Signature},
-    protocol::{Bytes, Bytes32, Program},
-};
+use chia_bls::{PublicKey, SecretKey, Signature};
+use chia_protocol::{Bytes, Bytes32, Program};
 use napi::bindgen_prelude::*;
 use napi::Result;
 use thiserror::Error;
@@ -384,9 +382,9 @@ impl ToJs<js::SpendBundle> for types::SpendBundle {
     }
 }
 
-impl FromJs<js::NftMetadata> for chia::puzzles::nft::NftMetadata {
+impl FromJs<js::NftMetadata> for chia_puzzle_types::nft::NftMetadata {
     fn from_js(value: js::NftMetadata) -> Result<Self> {
-        Ok(chia::puzzles::nft::NftMetadata {
+        Ok(chia_puzzle_types::nft::NftMetadata {
             data_uris: value.data_uris,
             data_hash: if let Some(hash) = value.data_hash {
                 Some(Bytes32::from_js(hash)?)
@@ -419,7 +417,7 @@ impl FromJs<js::NftMetadata> for chia::puzzles::nft::NftMetadata {
     }
 }
 
-impl ToJs<js::NftMetadata> for chia::puzzles::nft::NftMetadata {
+impl ToJs<js::NftMetadata> for chia_puzzle_types::nft::NftMetadata {
     fn to_js(&self) -> Result<js::NftMetadata> {
         Ok(js::NftMetadata {
             data_uris: self.data_uris.clone(),

--- a/napi/src/napi_lib.rs
+++ b/napi/src/napi_lib.rs
@@ -15,9 +15,9 @@ use datalayer_driver::{
     Signature as RustSignature, SpendBundle as RustSpendBundle,
 };
 
-use chia::protocol::{CoinStateUpdate, NewPeakWallet, ProtocolMessageTypes};
-use chia::puzzles::{standard::StandardArgs, DeriveSynthetic};
-use chia::traits::Streamable;
+use chia_protocol::{CoinStateUpdate, NewPeakWallet, ProtocolMessageTypes};
+use chia_puzzle_types::{standard::StandardArgs, DeriveSynthetic};
+use chia_traits::Streamable;
 use chia_wallet_sdk::client::{
     connect_peer, create_native_tls_connector, load_ssl_cert, Connector, PeerOptions,
 };
@@ -1757,7 +1757,7 @@ pub async fn mint_nft(
         .collect::<Result<Vec<RustCoin>>>()
         .map_err(crate::js::err)?;
     let recipient_puzzle_hash = RustBytes32::from_js(recipient_puzzle_hash)?;
-    let metadata = chia::puzzles::nft::NftMetadata::from_js(metadata)?;
+    let metadata = chia_puzzle_types::nft::NftMetadata::from_js(metadata)?;
     let royalty_puzzle_hash = if let Some(hash) = royalty_puzzle_hash {
         Some(RustBytes32::from_js(hash)?)
     } else {

--- a/src/dig_coin.rs
+++ b/src/dig_coin.rs
@@ -1,8 +1,8 @@
 use crate::error::WalletError;
 use crate::wallet::DIG_ASSET_ID;
 use crate::{Bytes32, Coin, Peer};
-use chia::protocol::CoinState;
-use chia::puzzles::cat::CatArgs;
+use chia_protocol::CoinState;
+use chia_puzzle_types::cat::CatArgs;
 use chia_wallet_sdk::driver::{Asset, Cat, Puzzle, SpendContext};
 use chia_wallet_sdk::prelude::{TreeHash, MAINNET_CONSTANTS};
 

--- a/src/dig_collateral_coin.rs
+++ b/src/dig_collateral_coin.rs
@@ -4,8 +4,8 @@ use crate::wallet::DIG_ASSET_ID;
 use crate::{
     Bytes, Bytes32, Coin, CoinSpend, CoinState, LineageProof, P2ParentCoin, Peer, PublicKey,
 };
-use chia::puzzles::Memos;
-use chia::traits::Streamable;
+use chia_puzzle_types::Memos;
+use chia_traits::Streamable;
 use chia_wallet_sdk::driver::{
     Action, Id, Puzzle, Relation, SpendContext, SpendWithConditions, Spends, StandardLayer,
 };

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use chia::consensus::validation_error::ValidationErr;
+use chia_consensus::validation_error::ValidationErr;
 use chia_wallet_sdk::client::ClientError;
 use chia_wallet_sdk::driver::DriverError;
 use thiserror::Error;
@@ -33,13 +33,13 @@ pub enum WalletError {
     Clvm,
 
     #[error("ToClvm error: {0}")]
-    ToClvm(#[from] chia::clvm_traits::ToClvmError),
+    ToClvm(#[from] clvm_traits::ToClvmError),
 
     #[error("Permission error: puzzle can't perform this action")]
     Permission,
 
-    #[error("Io error: {0}")]
-    Io(std::io::Error),
+    #[error("Consensus error: {0:?}")]
+    Consensus(#[from] chia_consensus::error::Error),
 
     #[error("Validation error: {0}")]
     Validation(#[from] ValidationErr),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@
 //! - Fee management utilities
 
 // Re-export core types from dependencies
-pub use chia::bls::{master_to_wallet_unhardened, PublicKey, SecretKey, Signature};
-pub use chia::protocol::{Bytes, Bytes32, Coin, CoinSpend, CoinState, Program, SpendBundle};
-pub use chia::puzzles::{EveProof, LineageProof, Proof};
+pub use chia_bls::{master_to_wallet_unhardened, PublicKey, SecretKey, Signature};
+pub use chia_protocol::{Bytes, Bytes32, Coin, CoinSpend, CoinState, Program, SpendBundle};
+pub use chia_puzzle_types::{EveProof, LineageProof, Proof};
 pub use chia_wallet_sdk::client::Peer;
 pub use chia_wallet_sdk::driver::{
     DataStore, DataStoreInfo, DataStoreMetadata, DelegatedPuzzle, P2ParentCoin,
@@ -57,7 +57,7 @@ use hex_literal::hex;
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 // Helper functions for common conversions
-use chia::puzzles::{standard::StandardArgs, DeriveSynthetic};
+use chia_puzzle_types::{standard::StandardArgs, DeriveSynthetic};
 // Helper functions for common conversions
 use xch_server_coin::NewXchServerCoin;
 
@@ -126,7 +126,7 @@ pub fn address_to_puzzle_hash(address: &str) -> Result<Bytes32> {
 
 /// Converts hex-encoded spend bundle to coin spends.
 pub fn hex_spend_bundle_to_coin_spends(hex: &str) -> Result<Vec<CoinSpend>> {
-    use chia::traits::Streamable;
+    use chia_traits::Streamable;
     let bytes = hex::decode(hex)?;
     let spend_bundle = SpendBundle::from_bytes(&bytes)?;
     Ok(spend_bundle.coin_spends)
@@ -134,7 +134,7 @@ pub fn hex_spend_bundle_to_coin_spends(hex: &str) -> Result<Vec<CoinSpend>> {
 
 /// Converts a spend bundle to hex encoding.
 pub fn spend_bundle_to_hex(spend_bundle: &SpendBundle) -> Result<String> {
-    use chia::traits::Streamable;
+    use chia_traits::Streamable;
     let bytes = spend_bundle.to_bytes()?;
     Ok(hex::encode(bytes))
 }
@@ -484,7 +484,7 @@ pub mod async_api {
         selected_coins: Vec<Coin>,
         did_string: &str,
         recipient_puzzle_hash: Bytes32,
-        metadata: chia::puzzles::nft::NftMetadata,
+        metadata: chia_puzzle_types::nft::NftMetadata,
         royalty_puzzle_hash: Option<Bytes32>,
         royalty_basis_points: u16,
         fee: u64,
@@ -618,7 +618,7 @@ pub mod async_api {
     pub async fn broadcast_spend_bundle(
         peer: &Peer,
         spend_bundle: SpendBundle,
-    ) -> Result<chia::protocol::TransactionAck> {
+    ) -> Result<chia_protocol::TransactionAck> {
         Ok(wallet::broadcast_spend_bundle(peer, spend_bundle).await?)
     }
 }
@@ -628,12 +628,12 @@ pub mod constants {
     use chia_wallet_sdk::types::{MAINNET_CONSTANTS, TESTNET11_CONSTANTS};
 
     /// Returns the mainnet genesis challenge.
-    pub fn get_mainnet_genesis_challenge() -> chia::protocol::Bytes32 {
+    pub fn get_mainnet_genesis_challenge() -> chia_protocol::Bytes32 {
         MAINNET_CONSTANTS.genesis_challenge
     }
 
     /// Returns the testnet11 genesis challenge.
-    pub fn get_testnet11_genesis_challenge() -> chia::protocol::Bytes32 {
+    pub fn get_testnet11_genesis_challenge() -> chia_protocol::Bytes32 {
         TESTNET11_CONSTANTS.genesis_challenge
     }
 }
@@ -691,7 +691,7 @@ mod examples {
         let selected_coins = select_coins(&unspent_coins.coin_states.iter().map(|cs| cs.coin).collect::<Vec<_>>(), fee + 1).unwrap();
 
         // 5. Create NFT metadata
-        let metadata = chia::puzzles::nft::NftMetadata {
+        let metadata = chia_puzzle_types::nft::NftMetadata {
             data_uris: vec!["https://example.com/nft.png".to_string()],
             metadata_uris: vec!["https://example.com/metadata.json".to_string()],
             ..Default::default()

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,8 @@
 pub use crate::xch_server_coin::XchServerCoin;
 use crate::DataStore;
-use chia::bls::{PublicKey, SecretKey};
-pub use chia::protocol::*;
-pub use chia::puzzles::{EveProof, LineageProof, Proof};
+use chia_bls::{PublicKey, SecretKey};
+pub use chia_protocol::*;
+pub use chia_puzzle_types::{EveProof, LineageProof, Proof};
 use chia_wallet_sdk::coinset::CoinRecord;
 
 pub struct SimulatorPuzzle {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,6 @@ use crate::DataStore;
 use chia_bls::{PublicKey, SecretKey};
 pub use chia_protocol::*;
 pub use chia_puzzle_types::{EveProof, LineageProof, Proof};
-use chia_wallet_sdk::coinset::CoinRecord;
 
 pub struct SimulatorPuzzle {
     pub puzzle_hash: Bytes32,
@@ -47,7 +46,9 @@ pub struct UnspentCoinStates {
     pub last_height: u32,
     pub last_header_hash: Bytes32,
 }
-pub fn coin_records_to_states(coin_records: Vec<CoinRecord>) -> Vec<CoinState> {
+pub fn coin_records_to_states(
+    coin_records: Vec<chia_wallet_sdk::coinset::CoinRecord>,
+) -> Vec<CoinState> {
     coin_records
         .into_iter()
         .map(|coin_record| CoinState {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -9,20 +9,20 @@ pub use crate::types::{coin_records_to_states, SuccessResponse, XchServerCoin};
 use crate::types::{EveProof, LineageProof, Proof};
 use crate::xch_server_coin::{urls_from_conditions, MirrorArgs, MirrorSolution, NewXchServerCoin};
 use crate::{NetworkType, UnspentCoinStates};
-use chia::bls::{sign, verify, PublicKey, SecretKey, Signature};
-use chia::clvm_traits::{clvm_tuple, FromClvm, ToClvm};
-use chia::clvm_utils::tree_hash;
-use chia::consensus::consensus_constants::ConsensusConstants;
-use chia::consensus::flags::{DONT_VALIDATE_SIGNATURE, MEMPOOL_MODE};
-use chia::consensus::owned_conditions::OwnedSpendBundleConditions;
-use chia::consensus::run_block_generator::run_block_generator;
-use chia::consensus::solution_generator::solution_generator;
-use chia::protocol::{
+use chia_bls::{sign, verify, PublicKey, SecretKey, Signature};
+use clvm_traits::{clvm_tuple, FromClvm, ToClvm};
+use clvm_utils::tree_hash;
+use chia_consensus::consensus_constants::ConsensusConstants;
+use chia_consensus::flags::{DONT_VALIDATE_SIGNATURE, MEMPOOL_MODE};
+use chia_consensus::owned_conditions::OwnedSpendBundleConditions;
+use chia_consensus::run_block_generator::run_block_generator;
+use chia_consensus::solution_generator::solution_generator;
+use chia_protocol::{
     Bytes, Bytes32, Coin, CoinSpend, CoinState, CoinStateFilters, RejectHeaderRequest,
     RequestBlockHeader, RequestFeeEstimates, RespondBlockHeader, RespondFeeEstimates, SpendBundle,
     TransactionAck,
 };
-use chia::puzzles::{
+use chia_puzzle_types::{
     nft::NftMetadata,
     standard::{StandardArgs, StandardSolution},
     DeriveSynthetic,
@@ -1125,7 +1125,7 @@ pub fn get_cost(coin_spends: Vec<CoinSpend>) -> Result<u64, WalletError> {
             .into_iter()
             .map(|cs| (cs.coin, cs.puzzle_reveal, cs.solution)),
     )
-    .map_err(WalletError::Io)?;
+    ?;
 
     let conds = run_block_generator::<&[u8], _>(
         &mut alloc,
@@ -1246,11 +1246,11 @@ pub async fn mint_nft(
 
     // Convert DID proof
     let did_proof = match did_proof {
-        chia::puzzles::Proof::Eve(eve) => Proof::Eve(EveProof {
+        chia_puzzle_types::Proof::Eve(eve) => Proof::Eve(EveProof {
             parent_parent_coin_info: eve.parent_parent_coin_info,
             parent_amount: eve.parent_amount,
         }),
-        chia::puzzles::Proof::Lineage(lineage) => Proof::Lineage(LineageProof {
+        chia_puzzle_types::Proof::Lineage(lineage) => Proof::Lineage(LineageProof {
             parent_parent_coin_info: lineage.parent_parent_coin_info,
             parent_inner_puzzle_hash: lineage.parent_inner_puzzle_hash,
             parent_amount: lineage.parent_amount,
@@ -1332,7 +1332,7 @@ pub async fn generate_did_proof(
     peer: &Peer,
     did_coin: Coin,
     network: TargetNetwork,
-) -> Result<(chia::puzzles::Proof, Coin), WalletError> {
+) -> Result<(chia_puzzle_types::Proof, Coin), WalletError> {
     let proof = generate_did_proof_from_chain(peer, did_coin, network).await?;
     Ok((proof, did_coin))
 }
@@ -1350,14 +1350,14 @@ pub fn generate_did_proof_manual(
     did_coin: Coin,
     parent_coin: Option<Coin>,
     parent_inner_puzzle_hash: Option<Bytes32>,
-) -> Result<chia::puzzles::Proof, WalletError> {
+) -> Result<chia_puzzle_types::Proof, WalletError> {
     match parent_coin {
         // Eve proof - first spend from launcher
         None => {
             // For eve proof, we need the launcher coin info
             // The parent_parent_coin_info is the coin that created the launcher
             // The parent_amount is the launcher coin amount (typically 1 mojo)
-            Ok(chia::puzzles::Proof::Eve(chia::puzzles::EveProof {
+            Ok(chia_puzzle_types::Proof::Eve(chia_puzzle_types::EveProof {
                 parent_parent_coin_info: did_coin.parent_coin_info,
                 parent_amount: 1, // Launcher coins are typically 1 mojo
             }))
@@ -1368,7 +1368,7 @@ pub fn generate_did_proof_manual(
                 "Parent inner puzzle hash is required".to_string(),
             ))?; // Need inner puzzle hash for lineage proof
 
-            Ok(chia::puzzles::Proof::Lineage(chia::puzzles::LineageProof {
+            Ok(chia_puzzle_types::Proof::Lineage(chia_puzzle_types::LineageProof {
                 parent_parent_coin_info: parent.parent_coin_info,
                 parent_inner_puzzle_hash,
                 parent_amount: parent.amount,
@@ -1390,7 +1390,7 @@ pub async fn generate_did_proof_from_chain(
     peer: &Peer,
     did_coin: Coin,
     network: TargetNetwork,
-) -> Result<chia::puzzles::Proof, WalletError> {
+) -> Result<chia_puzzle_types::Proof, WalletError> {
     // Get the parent coin state
     let parent_coin_states = peer
         .request_coin_state(
@@ -1411,7 +1411,7 @@ pub async fn generate_did_proof_from_chain(
     // Check if parent is a launcher (puzzle hash matches singleton launcher)
     if parent_coin_state.coin.puzzle_hash == SINGLETON_LAUNCHER_HASH.into() {
         // This is an eve proof - first spend from launcher
-        return Ok(chia::puzzles::Proof::Eve(chia::puzzles::EveProof {
+        return Ok(chia_puzzle_types::Proof::Eve(chia_puzzle_types::EveProof {
             parent_parent_coin_info: parent_coin_state.coin.parent_coin_info,
             parent_amount: parent_coin_state.coin.amount,
         }));
@@ -1431,7 +1431,7 @@ pub async fn generate_did_proof_from_chain(
 
     // For now, create a basic lineage proof
     // This is a simplified approach - in production you'd want to properly parse the parent DID
-    Ok(chia::puzzles::Proof::Lineage(chia::puzzles::LineageProof {
+    Ok(chia_puzzle_types::Proof::Lineage(chia_puzzle_types::LineageProof {
         parent_parent_coin_info: parent_coin_state.coin.parent_coin_info,
         parent_inner_puzzle_hash: Bytes32::default(), // Would need to parse from parent spend
         parent_amount: parent_coin_state.coin.amount,
@@ -1518,7 +1518,7 @@ pub async fn resolve_did_string_and_generate_proof(
     peer: &Peer,
     did_string: &str,
     network: TargetNetwork,
-) -> Result<(chia::puzzles::Proof, Coin), WalletError> {
+) -> Result<(chia_puzzle_types::Proof, Coin), WalletError> {
     // Parse DID string to extract launcher ID
     let parts: Vec<&str> = did_string.split(':').collect();
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -10,8 +10,6 @@ use crate::types::{EveProof, LineageProof, Proof};
 use crate::xch_server_coin::{urls_from_conditions, MirrorArgs, MirrorSolution, NewXchServerCoin};
 use crate::{NetworkType, UnspentCoinStates};
 use chia_bls::{sign, verify, PublicKey, SecretKey, Signature};
-use clvm_traits::{clvm_tuple, FromClvm, ToClvm};
-use clvm_utils::tree_hash;
 use chia_consensus::consensus_constants::ConsensusConstants;
 use chia_consensus::flags::{DONT_VALIDATE_SIGNATURE, MEMPOOL_MODE};
 use chia_consensus::owned_conditions::OwnedSpendBundleConditions;
@@ -41,6 +39,8 @@ use chia_wallet_sdk::types::{
     Condition, Conditions, MAINNET_CONSTANTS, TESTNET11_CONSTANTS,
 };
 use chia_wallet_sdk::utils::{self, CoinSelectionError};
+use clvm_traits::{clvm_tuple, FromClvm, ToClvm};
+use clvm_utils::tree_hash;
 use clvmr::Allocator;
 use hex_literal::hex;
 
@@ -1124,8 +1124,7 @@ pub fn get_cost(coin_spends: Vec<CoinSpend>) -> Result<u64, WalletError> {
         coin_spends
             .into_iter()
             .map(|cs| (cs.coin, cs.puzzle_reveal, cs.solution)),
-    )
-    ?;
+    )?;
 
     let conds = run_block_generator::<&[u8], _>(
         &mut alloc,
@@ -1368,11 +1367,13 @@ pub fn generate_did_proof_manual(
                 "Parent inner puzzle hash is required".to_string(),
             ))?; // Need inner puzzle hash for lineage proof
 
-            Ok(chia_puzzle_types::Proof::Lineage(chia_puzzle_types::LineageProof {
-                parent_parent_coin_info: parent.parent_coin_info,
-                parent_inner_puzzle_hash,
-                parent_amount: parent.amount,
-            }))
+            Ok(chia_puzzle_types::Proof::Lineage(
+                chia_puzzle_types::LineageProof {
+                    parent_parent_coin_info: parent.parent_coin_info,
+                    parent_inner_puzzle_hash,
+                    parent_amount: parent.amount,
+                },
+            ))
         }
     }
 }
@@ -1431,11 +1432,13 @@ pub async fn generate_did_proof_from_chain(
 
     // For now, create a basic lineage proof
     // This is a simplified approach - in production you'd want to properly parse the parent DID
-    Ok(chia_puzzle_types::Proof::Lineage(chia_puzzle_types::LineageProof {
-        parent_parent_coin_info: parent_coin_state.coin.parent_coin_info,
-        parent_inner_puzzle_hash: Bytes32::default(), // Would need to parse from parent spend
-        parent_amount: parent_coin_state.coin.amount,
-    }))
+    Ok(chia_puzzle_types::Proof::Lineage(
+        chia_puzzle_types::LineageProof {
+            parent_parent_coin_info: parent_coin_state.coin.parent_coin_info,
+            parent_inner_puzzle_hash: Bytes32::default(), // Would need to parse from parent spend
+            parent_amount: parent_coin_state.coin.amount,
+        },
+    ))
 }
 
 /// Creates a simple DID from a private key and selected coins.
@@ -1677,4 +1680,80 @@ pub async fn resolve_did_string_and_generate_proof(
     let proof = generate_did_proof_from_chain(peer, current_did_coin, network).await?;
 
     Ok((proof, current_did_coin))
+}
+
+#[cfg(test)]
+mod melt_kat {
+    //! Custody KAT pinning `DataStore::from_spend`'s melt signal under the
+    //! chia-wallet-sdk 0.34 family (dig_ecosystem#2133).
+    //!
+    //! The just-merged digstore-chain #1981 melt classifier depends on the load-
+    //! bearing fact that a childless datastore singleton spend (an owner melt)
+    //! surfaces as `Err(DriverError::MissingChild)`, while a spend that recreates
+    //! the datastore surfaces as `Ok(Some(_))`. This test drives a real
+    //! peer-simulator mint -> melt and asserts both signals hold under 0.34.
+    use super::*;
+    use chia_wallet_sdk::test::{BlsPair, Simulator};
+
+    #[test]
+    fn from_spend_reports_owner_melt_as_missing_child() -> anyhow::Result<()> {
+        let mut sim = Simulator::new();
+        let owner = BlsPair::default();
+
+        // In the simulator the standard puzzle is curried directly on the pair's
+        // public key, so that key doubles as the "synthetic" key our wallet API
+        // expects and the pair's secret key signs the spends.
+        let owner_puzzle_hash: Bytes32 = StandardArgs::curry_tree_hash(owner.pk).into();
+        let funding_coin = sim.new_coin(owner_puzzle_hash, 1);
+
+        // Mint a datastore (no delegation layers, zero fee) and land it on chain.
+        let minted = mint_store(
+            owner.pk,
+            vec![funding_coin],
+            Bytes32::new([1; 32]),
+            None,
+            None,
+            None,
+            None,
+            owner_puzzle_hash,
+            vec![],
+            0,
+        )?;
+        let datastore = minted.new_datastore.clone();
+        sim.spend_coins(minted.coin_spends.clone(), std::slice::from_ref(&owner.sk))?;
+
+        // Positive control: the launcher spend that CREATES the datastore (it
+        // recreates the singleton with an odd-amount child) must be recognised as
+        // a datastore, i.e. `Ok(Some(_))`. This proves `from_spend` genuinely
+        // inspects the recreated child rather than returning the melt signal for
+        // every datastore singleton spend.
+        let mut ctx = SpendContext::new();
+        let launcher_spend = minted
+            .coin_spends
+            .iter()
+            .find(|cs| cs.coin.puzzle_hash == SINGLETON_LAUNCHER_HASH.into())
+            .expect("mint must contain the singleton launcher spend");
+        let launched = DataStore::<DataStoreMetadata>::from_spend(&mut ctx, launcher_spend, &[])?;
+        assert!(
+            launched.is_some(),
+            "from_spend must recognise the datastore-creating launcher spend as Ok(Some)"
+        );
+
+        // Melt the datastore and land the melt on chain (proving it is a valid,
+        // fully-executable datastore singleton spend, not a malformed one).
+        let melt_spends = melt_store(datastore, owner.pk)?;
+        assert_eq!(melt_spends.len(), 1, "melt produces exactly one spend");
+        sim.spend_coins(melt_spends.clone(), std::slice::from_ref(&owner.sk))?;
+
+        // The pinned property: a valid datastore singleton spend that recreates no
+        // odd-amount child (the owner melt) is reported as `Err(MissingChild)`.
+        let mut ctx = SpendContext::new();
+        let result = DataStore::<DataStoreMetadata>::from_spend(&mut ctx, &melt_spends[0], &[]);
+        assert!(
+            matches!(result, Err(DriverError::MissingChild)),
+            "0.34 must still surface an owner melt as Err(DriverError::MissingChild), got {result:?}"
+        );
+
+        Ok(())
+    }
 }

--- a/src/xch_server_coin.rs
+++ b/src/xch_server_coin.rs
@@ -133,7 +133,7 @@ pub fn urls_from_conditions(
 
 #[cfg(test)]
 mod tests {
-    use chia::clvm_utils::tree_hash;
+    use clvm_utils::tree_hash;
     use clvmr::{serde::node_from_bytes, Allocator};
 
     use super::*;


### PR DESCRIPTION
Closes DIG-Network/dig_ecosystem#2133. Release-first head of the cascade unblocking dig_ecosystem#1253 → hub #181/#182.

## What
Migrates `datalayer-driver` (both workspace members — the root crate and the `napi/` native bindings) from the chia-wallet-sdk **0.30** family to **0.34**, and bumps the crate **3.0.0 → 4.0.0** (major — breaking chia-family bump for consumers).

**Final dependency family** (verified against chia-wallet-sdk 0.34.0's own crates.io pins, single non-duplicated graph):
`chia-wallet-sdk` **0.34.0** (`chip-0035`, `native-tls`, `peer-simulator`, `action-layer`, `offer-compression`) · `chia-protocol` **0.36.1** · `chia-puzzle-types` **0.36.1** (new) · `chia-puzzles` **0.20.3** · `clvm-traits`/`clvm-utils` **0.36.1** · `clvmr` **0.16.x** · `chia-bls`/`chia-consensus`/`chia-traits` **0.36.1**. `cargo tree -i chia-protocol` → exactly one `v0.36.1`.

## Notable change — the `chia` umbrella crate was dropped
The `chia` umbrella skips the entire 0.36 protocol line (jumps 0.32 → 0.42), and chia-wallet-sdk 0.34 depends on `chia-protocol` 0.36.1 directly. Keeping the umbrella would force a duplicate chia-protocol family into the graph. It was replaced with its constituent sub-crates (`chia-protocol`, `chia-bls`, `chia-consensus`, `chia-traits`, `clvm-utils`) at 0.36.1, rewriting `chia::protocol::X` → `chia_protocol::X`, etc. Pure re-pathing to the same types.

## Other API changes absorbed
- Puzzle types (`Proof`/`EveProof`/`LineageProof`, `cat`/`nft`/`standard`, `Memos`, `DeriveSynthetic`) relocated `chia-puzzles` → new `chia-puzzle-types` (bytecode/constants stay in `chia-puzzles`; `SINGLETON_LAUNCHER_HASH` byte-identical).
- `chia_consensus::solution_generator` now returns `chia_consensus::error::Error` (was `std::io::Error`): `WalletError::Io` → `WalletError::Consensus(#[from] …)`; `get_cost` call site simplified to `?` (read-only estimator; propagate-on-error unchanged).
- `chia-protocol` 0.36 newly exports `CoinRecord`, which shadowed the coinset `CoinRecord` under `pub use chia_protocol::*` — resolved by fully-qualifying the coinset type in `types.rs`.

## Custody: `from_spend` melt signature is UNCHANGED in 0.34
This crate's `melt_store`/`from_spend` behavior is the load-bearing signal for the downstream digstore-chain #1981 melt classifier (authorizes an irreversible delete). Verified independently at source (`chia-sdk-driver-0.34.0/.../datastore.rs:341`): an owner melt (childless datastore-singleton spend) still returns `Err(DriverError::MissingChild)` (no `#[from]`, so no parse/CLVM error coerces into it); a non-datastore terminal still returns `Ok(None)`. The 0.30 vs 0.34 `from_spend` bodies differ by a single blank line. A new peer-simulator KAT (`src/wallet.rs mod melt_kat`) mints → melts → asserts `from_spend` returns `MissingChild`, with a positive control (launcher → `Ok(Some)`) and both bundles executed on the simulator; mutation-proven load-bearing.

## Gates
- Dual custody gate (this crate builds real spend bundles): **loop-security PASS** (melt signature source-verified unchanged; `mint_store`/`melt_store` bodies unchanged; no spend-bundle drift; no custody constant widened / no secret logged), **loop-reviewer PASS** (all type-path rewrites semantic-neutral; spend-building bodies logically unchanged; melt KAT mutation-proven).
- Local, exact CI invocations: `cargo fmt --check` clean · `cargo clippy --all-targets --all-features -- -D warnings` **clean** (rust 1.97.1, forced re-lint) · `cargo machete` clean · `cargo test --workspace` green (incl. the peer-simulator custody KAT) · `cargo build --workspace` (both members).

## Downstream (separate tickets)
dig_ecosystem#1253 (digstore-chain adopts this + re-verifies #1981) → hub #181 re-pin + dependabot-hold drop (#182). Consumers pinning `chia = "0.26"` alongside a 0.34 SDK will hit the same umbrella wall and must migrate to the sub-crates.

---
_Generated by [Claude Code](https://claude.ai/code/session_019hf5T5ihDXNhBQoFK2qHpH)_