### PR TITLE
ci(publish): let npm trusted publishing actually engage, and guard publish on the ref

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -269,6 +269,7 @@ jobs:
   publish-npm:
     name: Publish to NPM
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding
@@ -296,17 +297,17 @@ jobs:
       - name: List packages
         run: ls -R ./napi/npm
         shell: bash
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
       - name: Publish to NPM
         run: |
           cd napi
-          npm config set provenance true
+          npm --version
           if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
           then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --access public
           elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
           then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --tag next --access public
           else
             echo "Not a release, skipping npm publish"
@@ -318,6 +319,7 @@ jobs:
   publish-crates:
     name: Publish to Crates.io
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding


### PR DESCRIPTION
Closes the four-day red on `main` (run 30933629367) and unblocks npm.

## Why the publish has been failing

`main`'s last CI run failed with:

```
npm error code EOTP
npm error This operation requires a one-time password from your authenticator.
```

The repo already grants `id-token: write` at the top level, so the OIDC half is wired. But the publish step wrote a token into `~/.npmrc` immediately before `npm publish`:

```
echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
npm publish --access public
```

**When a token is present npm authenticates with it and never attempts the OIDC exchange** — so trusted publishing could not engage, and the token path requires a 2FA code no runner can produce.

Consequence: npm serves **3.0.0** while `Cargo.toml` is at **4.0.0** — a full major behind, since 2026-08-04.

## Changes

1. **Drop both `_authToken` writes**, so npm falls through to trusted publishing.
2. **Upgrade npm explicitly** — trusted publishing needs npm >= 11.5.1 and Node 20 ships npm 10.x. Done as `npm install -g npm@latest` rather than by bumping `node-version`, so the toolchain the native addon is packaged with is unchanged.
3. **Guard both publish jobs on `push` to `refs/heads/main`.**

## On change 3

Both publish jobs previously ran on `pull_request` with `NPM_TOKEN` in `env`. The only thing preventing a PR-branch publish was that the commit message did not match a version regex — and on `pull_request` the checkout lands on `refs/pull/N/merge`, whose GitHub-generated message can never match.

That is an accident of GitHub's message format, not a control. The `elif` is also unanchored (`^[0-9]+\.[0-9]+\.[0-9]+` with no `$`) and `git log -1 --pretty=%B` is matched line-by-line, so any line of a squash body starting with a version string could trigger a `--tag next` publish.

## Verification

`npm config set provenance true` is removed because trusted publishing attaches provenance automatically. `NPM_TOKEN` remains in `env` but is now inert — nothing writes it anywhere.

This cannot be proven green by CI alone: the publish job will correctly skip on this PR (it is not a push to main). **The real check is that after merge, npm serves 4.x** — verify against the registry, not the run's conclusion.

Refs DIG-Network/dig_ecosystem#2380